### PR TITLE
mise à jour wordpress en 5.8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "johnpbloch/wordpress": "5.7.2",
+        "johnpbloch/wordpress": "5.8.3",
         "wpackagist-plugin/cookie-law-info" : "1.5.3",
         "wpackagist-plugin/eu-cookie-law" : "3.1.6",
         "wpackagist-plugin/custom-javascript-editor" : "1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea15e65a5729ca88e6b0bc2e41637d21",
+    "content-hash": "55928e6fa025fe386d3789aae62ef781",
     "packages": [
         {
             "name": "composer/installers",
@@ -140,20 +140,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "5.7.2",
+            "version": "5.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "be44aeabc63a584a4b1ef4a193f36c3f710a162a"
+                "reference": "ecec9cf67c91c2ff31b1002035e8e8a1a6c91292"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/be44aeabc63a584a4b1ef4a193f36c3f710a162a",
-                "reference": "be44aeabc63a584a4b1ef4a193f36c3f710a162a",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/ecec9cf67c91c2ff31b1002035e8e8a1a6c91292",
+                "reference": "ecec9cf67c91c2ff31b1002035e8e8a1a6c91292",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "5.7.2",
+                "johnpbloch/wordpress-core": "5.8.3",
                 "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
                 "php": ">=5.6.20"
             },
@@ -175,20 +175,27 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2021-05-13T00:40:29+00:00"
+            "support": {
+                "forum": "http://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "http://core.trac.wordpress.org/",
+                "source": "http://core.trac.wordpress.org/browser",
+                "wiki": "http://codex.wordpress.org/"
+            },
+            "time": "2022-01-06T19:24:21+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.7.2",
+            "version": "5.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "d0f5bdeb81800b6bcefee723ebf928b5677e2e86"
+                "reference": "9f80e45b0a8116df03a41e4ccea09a434528b063"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/d0f5bdeb81800b6bcefee723ebf928b5677e2e86",
-                "reference": "d0f5bdeb81800b6bcefee723ebf928b5677e2e86",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/9f80e45b0a8116df03a41e4ccea09a434528b063",
+                "reference": "9f80e45b0a8116df03a41e4ccea09a434528b063",
                 "shasum": ""
             },
             "require": {
@@ -196,7 +203,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.7.2"
+                "wordpress/core-implementation": "5.8.3"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -216,7 +223,14 @@
                 "cms",
                 "wordpress"
             ],
-            "time": "2021-05-13T00:40:25+00:00"
+            "support": {
+                "forum": "https://wordpress.org/support/",
+                "irc": "irc://irc.freenode.net/wordpress",
+                "issues": "https://core.trac.wordpress.org/",
+                "source": "https://core.trac.wordpress.org/browser",
+                "wiki": "https://codex.wordpress.org/"
+            },
+            "time": "2022-01-06T19:24:18+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -266,6 +280,10 @@
             "keywords": [
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/johnpbloch/wordpress-core-installer/issues",
+                "source": "https://github.com/johnpbloch/wordpress-core-installer/tree/master"
+            },
             "time": "2020-04-16T21:44:57+00:00"
         },
         {
@@ -430,8 +448,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/cookie-law-info.1.5.3.zip",
-                "reference": "tags/1.5.3",
-                "shasum": null
+                "reference": "tags/1.5.3"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -450,8 +467,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/custom-javascript-editor.1.1.zip",
-                "reference": "tags/1.1",
-                "shasum": null
+                "reference": "tags/1.1"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -470,8 +486,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/display-posts-shortcode.3.0.2.zip",
-                "reference": "tags/3.0.2",
-                "shasum": null
+                "reference": "tags/3.0.2"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -490,8 +505,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/easy-wp-smtp.zip?timestamp=1615348787",
-                "reference": "trunk",
-                "shasum": null
+                "reference": "trunk"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -510,8 +524,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/enhanced-media-library.2.4.4.zip",
-                "reference": "tags/2.4.4",
-                "shasum": null
+                "reference": "tags/2.4.4"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -530,8 +543,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/eu-cookie-law.zip?timestamp=1607465332",
-                "reference": "trunk",
-                "shasum": null
+                "reference": "trunk"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -550,8 +562,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/flickr-album-gallery.2.1.8.zip",
-                "reference": "tags/2.1.8",
-                "shasum": null
+                "reference": "tags/2.1.8"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -570,8 +581,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/google-sitemap-generator.4.1.1.zip",
-                "reference": "tags/4.1.1",
-                "shasum": null
+                "reference": "tags/4.1.1"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -590,8 +600,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/googleanalytics.2.5.1.zip",
-                "reference": "tags/2.5.1",
-                "shasum": null
+                "reference": "tags/2.5.1"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -610,8 +619,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/iframe.4.5.zip",
-                "reference": "tags/4.5",
-                "shasum": null
+                "reference": "tags/4.5"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -630,8 +638,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/insert-php.1.3.zip",
-                "reference": "tags/1.3",
-                "shasum": null
+                "reference": "tags/1.3"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -650,8 +657,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://downloads.wordpress.org/plugin/jquery-t-countdown-widget.2.3.16.zip",
-                "reference": "tags/2.3.16",
-                "shasum": null
+                "reference": "tags/2.3.16"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -669,9 +675,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/qtranslate-x.3.4.6.8.zip",
-                "reference": null,
-                "shasum": null
+                "url": "https://downloads.wordpress.org/plugin/qtranslate-x.3.4.6.8.zip"
             },
             "require": {
                 "composer/installers": "~1.0"
@@ -686,9 +690,12 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-curl": "*"
+    },
     "platform-dev": [],
     "platform-overrides": {
         "php": "5.6.29"
-    }
+    },
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
cf https://wordpress.org/news/2022/01/wordpress-5-8-3-security-release/