### PR TITLE
correction de l'accès aux entêtes et pied de page des interviews

### DIFF
--- a/resources/themes/hestia-pro_child/functions.php
+++ b/resources/themes/hestia-pro_child/functions.php
@@ -21,6 +21,13 @@ function afup_website_func($attrs) {
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
       }
 
+    $afupBlogApiKey = getenv('AFUP_BLOG_API_KEY');
+    if ($afupBlogApiKey) {
+      curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+          'X-Afup-Blog-Api-Key:' . $afupBlogApiKey,
+      ));
+    }
+
     curl_setopt($ch, CURLOPT_HEADER, false);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
     curl_setopt($ch, CURLOPT_URL, $url);


### PR DESCRIPTION
Les pages de programme/planning et speakers fonctionnaient mais
pas les blocs speaker et talk sur les interviews, et cela depuis
la migration sur clever.

Avec l'ajout de la variable d'environnement `AFUP_WEBSITE_URL`
se trouvant ici :
https://github.com/afup/event/blob/7907f393c855193e2e64cb2c3ae6ead44e1c63ac/resources/themes/hestia-pro_child/functions.php#L16

Cela permet de les faire fonctionner à nouveau.