### PR TITLE
ajout de redirections sur les speakers de l'AFUP Day

### DIFF
--- a/resources/web/.htaccess
+++ b/resources/web/.htaccess
@@ -9,6 +9,8 @@ RewriteRule ^en/(.*) $1 [L,R=302]
 RewriteRule ^forum-php-2017/programme/ /forumphp2017/programme [L,R=301]
 RewriteRule ^forum-php-2018/sponsors/ /forumphp2018/sponsors [L,R=301]
 RewriteRule ^forum-php-2018/accessibilite-et-inclusivite/ /forumphp2018/accessibilite-et-inclusivite [L,R=301]
+RewriteRule ^afupday2023lille/speakers/ /afup-day-2023/afup-day-2023-lille/conferencier-e-s/ [L,R=301]
+RewriteRule ^afupday2023lyon/speakers/ /afup-day-2023/afup-day-2023-lyon/conferencier-e-s/ [L,R=301]
 RewriteRule ^code-de-conduite https://afup.org/p/986-code-de-conduite [L,R=302]
 
 


### PR DESCRIPTION
sur https://afup.org/event/afupday2023lille/calendar les liens vers les speakers ne fonctionnent pas, on met en place des redirections pour les faire fonctionner.