### PR TITLE
on supprime le custom javascript editor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
         "johnpbloch/wordpress": "5.8.7",
         "wpackagist-plugin/cookie-law-info" : "1.5.3",
         "wpackagist-plugin/eu-cookie-law" : "3.1.6",
-        "wpackagist-plugin/custom-javascript-editor" : "1.1",
         "wpackagist-plugin/easy-wp-smtp" : "1.4.6",
         "wpackagist-plugin/enhanced-media-library" : "2.4.4",
         "wpackagist-plugin/flickr-album-gallery" : "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6b18668e82fc2f68da283afa3988488",
+    "content-hash": "d09d36a1b9caaa318fb59892505498d1",
     "packages": [
         {
             "name": "composer/installers",
@@ -455,25 +455,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/cookie-law-info/"
-        },
-        {
-            "name": "wpackagist-plugin/custom-javascript-editor",
-            "version": "1.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/custom-javascript-editor/",
-                "reference": "tags/1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/custom-javascript-editor.1.1.zip",
-                "reference": "tags/1.1"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/custom-javascript-editor/"
         },
         {
             "name": "wpackagist-plugin/display-posts-shortcode",


### PR DESCRIPTION
On est actuellement en version 5.8.7 qui tourne sur un PHP 5.4.

A partir de la 5.8.8 on devra passer sur une version 7 minimum : https://github.com/johnpbloch/wordpress/commit/d3b0895b02973ed869b9050f5c1551694390a4c2

Le plugin de custom javascript editor n'est pas compatible avec PHP 7.

Et il n'est plus maintenu : https://plugins.trac.wordpress.org/browser/custom-javascript-editor/tags

Il est utilisé pour saisir cela :

```
<script>/**<!-- Code Google de la balise de remarketing -->
<!--------------------------------------------------
Les balises de remarketing ne peuvent pas être associées aux informations personnelles ou placées sur des pages liées aux catégories à caractère sensible. Pour comprendre et savoir comment configurer la balise, rendez-vous sur la page http://google.com/ads/remarketingsetup.
---------------------------------------------------> */
/* <![CDATA[ */
var google_conversion_id = 878368884;
var google_custom_params = window.google_tag_params;
var google_remarketing_only = true;
/* ]]> */

document.write('<scr' + 'ipt type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js"></scr' + 'ipt>');</script>
```

On peux utiliser les hooks de notre thème pour cela : https://localhost:9225/wp-admin/themes.php?page=hestia_hooks_settings En mettant le script dans la partie `After Footer`.

On supprime donc ce plugin pour ensuite passer en 7.0 de php, pour ensuite passer en 5.8.8 de Wordpress.