### PR TITLE
on passe sous php7

### DIFF
--- a/docker/dockerfiles/event/Dockerfile
+++ b/docker/dockerfiles/event/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6-apache
+FROM php:7.0-apache
 
 RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
 


### PR DESCRIPTION
on était en version 5.6 de php, on passe à la version 7.0 (une autre mise à jour sera à prévoir plus tard),

cela permettra ensuite de passer sur la dernière mise à jour de sécurité de la 5.8 de wordpress (cf https://github.com/afup/event/pull/20)