### PR TITLE
suppression du plugin qtranslate-x non utilisé

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "wpackagist-plugin/iframe": "^4.5",
         "wpackagist-plugin/insert-php": "1.3",
         "wpackagist-plugin/jquery-t-countdown-widget": "2.3.16",
-        "wpackagist-plugin/qtranslate-x": "^3.4",
         "symfony/filesystem": "^3.3",
         "symfony/finder": "^3.3",
         "symfony/polyfill-ctype": "1.18.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d94b4856556776395257528ff3fd7f62",
+    "content-hash": "bcc4920c4a1ecd56c1dc15ece2578cd5",
     "packages": [
         {
             "name": "composer/installers",
@@ -663,24 +663,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/lktags-linkedin-insight-tags/"
-        },
-        {
-            "name": "wpackagist-plugin/qtranslate-x",
-            "version": "3.4.6.8",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/qtranslate-x/",
-                "reference": "tags/3.4.6.8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/qtranslate-x.3.4.6.8.zip"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/qtranslate-x/"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Afin de pouvoir monter la version de PHP, on supprime le plugin qtranslate-x qui n'est pas utilisé, il pose problème à partir de la version 7.2 de php.

![Screenshot 2023-10-19 at 14-20-30 AFUP Day 2024 – Le cycle de conférences multi-destinations de l'AFUP](https://github.com/afup/event/assets/320372/a40bb267-b0fc-4daa-80ef-a8e8dcdf63b6)
