### PR TITLE
on passe en php 7.4

### DIFF
--- a/docker/dockerfiles/event/Dockerfile
+++ b/docker/dockerfiles/event/Dockerfile
@@ -1,7 +1,5 @@
 FROM php:7.4-apache
 
-#RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
-
 # Install required php extensions for afup website and other management package
 RUN apt-get update && \
     apt-get install -y \

--- a/docker/dockerfiles/event/Dockerfile
+++ b/docker/dockerfiles/event/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:7.0-apache
+FROM php:7.4-apache
 
-RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+#RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
 
 # Install required php extensions for afup website and other management package
 RUN apt-get update && \
@@ -8,11 +8,11 @@ RUN apt-get update && \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        libzip-dev \
         libmcrypt4 \
-        libmcrypt-dev \
         wget && \
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
-    docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt && \
+    docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ && \
+    docker-php-ext-install pdo_mysql mysqli zip gd && \
     apt-get remove -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \


### PR DESCRIPTION
maintenant qu'on a traité https://github.com/afup/event/pull/23

et https://github.com/afup/event/pull/24

on peux passer en PHP 7.4

cela permet, même si PHP 7.0 fonctionne sur Clever CLoud d'être sur une version supportée dans la documentation : https://www.clever-cloud.com/doc/deploy/application/php/php-apps/