### PR TITLE
ajout d'un plugin de description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "symfony/polyfill-ctype": "1.18.0",
         "wpackagist-plugin/display-posts-shortcode": "^3.0",
         "ext-curl": "*",
-        "wpackagist-plugin/lktags-linkedin-insight-tags": "^1.2"
+        "wpackagist-plugin/lktags-linkedin-insight-tags": "^1.2",
+        "wpackagist-plugin/easy-wp-meta-description": "^1.2"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50fa49f1fd4d92c9807ea3cc24e7b730",
+    "content-hash": "b4f740d9b4c759de6966c87e2655d429",
     "packages": [
         {
             "name": "composer/installers",
@@ -474,6 +474,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/display-posts-shortcode/"
+        },
+        {
+            "name": "wpackagist-plugin/easy-wp-meta-description",
+            "version": "1.2.6",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/easy-wp-meta-description/",
+                "reference": "tags/1.2.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/easy-wp-meta-description.1.2.6.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/easy-wp-meta-description/"
         },
         {
             "name": "wpackagist-plugin/easy-wp-smtp",


### PR DESCRIPTION
Nous n'avions pas la possibilité de définir la description, cela pose des soucis de référencement, ce plugin (https://wordpress.com/plugins/easy-wp-meta-description) va permettre d'ajouter les descriptions.


![Capture d’écran du 2024-09-28 22-23-05](https://github.com/user-attachments/assets/c12a3032-bedd-45b0-a7cd-a6b251699143)


![Screenshot 2024-09-28 at 22-11-20 Modifier la page ‹ AFUP Day 2024 — WordPress](https://github.com/user-attachments/assets/90db992f-1d2a-4edc-8fc8-f4b72b887bd9)
