### PR TITLE
Désactivation des mises à jour automatique et de la modification de fichiers

### DIFF
--- a/resources/config/wp-config.php
+++ b/resources/config/wp-config.php
@@ -108,3 +108,9 @@ require_once(ABSPATH . 'wp-settings.php');
 
 define('FS_METHOD','direct');
 
+// Automatic updates
+define('AUTOMATIC_UPDATER_DISABLED', true);
+define('WP_AUTO_UPDATE_CORE', false);
+
+// Security
+define('DISALLOW_FILE_EDIT', true);


### PR DESCRIPTION
Ces 3 constantes permettent de renforcer la sécurité en:
- Désactivant les mises à jour du coeur et des extensions automatisées
- Désactivant la modification de fichiers depuis le backoffice

Cela évitera également ce qui se produit lors de la sortie d'une nouvelle mise à jour: le wordpress se met à jour seul puis revient à la version précédente lors d'un déploiement, ce qui peut également poser des problèmes dans le cas où le downgrade ne devait pas être bien supporté par une version.