### PR TITLE
on supprime wpackagist-plugin/enhanced-media-library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "require": {
         "johnpbloch/wordpress": "5.9.12",
         "wpackagist-plugin/easy-wp-smtp" : "1.4.6",
-        "wpackagist-plugin/enhanced-media-library" : "2.4.4",
         "wpackagist-plugin/flickr-album-gallery" : "^2.1",
         "wpackagist-plugin/google-sitemap-generator": "^4.1.21",
         "wpackagist-plugin/iframe": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbacc90d913e924ccf71e7969beab4d7",
+    "content-hash": "19eac430d4c6cebaaed477cc336cd0af",
     "packages": [
         {
             "name": "composer/installers",
@@ -582,25 +582,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/easy-wp-smtp/"
-        },
-        {
-            "name": "wpackagist-plugin/enhanced-media-library",
-            "version": "2.4.4",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/enhanced-media-library/",
-                "reference": "tags/2.4.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/enhanced-media-library.2.4.4.zip",
-                "reference": "tags/2.4.4"
-            },
-            "require": {
-                "composer/installers": "~1.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/enhanced-media-library/"
         },
         {
             "name": "wpackagist-plugin/flickr-album-gallery",


### PR DESCRIPTION
ce paquet est installé mais pas activé, ce n'est pas utile de le conserver.

<img width="1682" height="118" alt="Capture d’écran du 2025-11-01 17-52-32" src="https://github.com/user-attachments/assets/f156b042-1d31-4ded-8f76-dc546830d948" />
