### PR TITLE
mise à jour de WordPress de la version 5.9.12 à la 5.9.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "johnpbloch/wordpress": "5.9.12",
+        "johnpbloch/wordpress": "5.9.13",
         "wpackagist-plugin/easy-wp-smtp" : "1.4.6",
         "wpackagist-plugin/flickr-album-gallery" : "^2.1",
         "wpackagist-plugin/google-sitemap-generator": "^4.1.21",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19eac430d4c6cebaaed477cc336cd0af",
+    "content-hash": "af6998772b61a7f54d34b5ae7ca95760",
     "packages": [
         {
             "name": "composer/installers",
@@ -158,20 +158,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "5.9.12",
+            "version": "5.9.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "046db46b1a369e580c12726e133921b29721733a"
+                "reference": "3a72f597c9524671ade5816b8dbd302852ef7720"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/046db46b1a369e580c12726e133921b29721733a",
-                "reference": "046db46b1a369e580c12726e133921b29721733a",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/3a72f597c9524671ade5816b8dbd302852ef7720",
+                "reference": "3a72f597c9524671ade5816b8dbd302852ef7720",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "5.9.12",
+                "johnpbloch/wordpress-core": "5.9.13",
                 "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
                 "php": ">=7.0.0"
             },
@@ -200,20 +200,20 @@
                 "issues": "https://core.trac.wordpress.org/",
                 "source": "https://core.trac.wordpress.org/browser"
             },
-            "time": "2025-09-30T18:37:57+00:00"
+            "time": "2026-03-12T05:03:17+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.9.12",
+            "version": "5.9.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "e17b7aed6bb4d01fcba88a74e2621939d48c6cc7"
+                "reference": "308c80b9f4585c84ca08840806d10a2102580939"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/e17b7aed6bb4d01fcba88a74e2621939d48c6cc7",
-                "reference": "e17b7aed6bb4d01fcba88a74e2621939d48c6cc7",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/308c80b9f4585c84ca08840806d10a2102580939",
+                "reference": "308c80b9f4585c84ca08840806d10a2102580939",
                 "shasum": ""
             },
             "require": {
@@ -221,7 +221,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.9.12"
+                "wordpress/core-implementation": "5.9.13"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -248,7 +248,7 @@
                 "source": "https://core.trac.wordpress.org/browser",
                 "wiki": "https://codex.wordpress.org/"
             },
-            "time": "2025-09-30T18:37:53+00:00"
+            "time": "2026-03-12T05:03:15+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",


### PR DESCRIPTION
Cela permet de bénéficier de la dernière mise à jour de sécurité et ne plus recevoir de mail de mise à jour automatique régulièrement.